### PR TITLE
fix: missing logUpdater param

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ class UpdateRenderer {
 			this._id = undefined;
 		}
 
-		render(this._tasks, this._options);
+		render(this._tasks, this._logUpdater, this._options);
 
 		if (this._options.clearOutput && err === undefined) {
 			this._logUpdater.clear();


### PR DESCRIPTION
When successfully ending with this error, the `options` were undefined because we were missing a param.